### PR TITLE
 Refactoring for compatibility with TYPO3 v10

### DIFF
--- a/Documentation/Tutorials/XpathAndStdwrap/Index.rst
+++ b/Documentation/Tutorials/XpathAndStdwrap/Index.rst
@@ -44,7 +44,7 @@ TypoScript:
 
      10 = XPATH
      10 {
-        source.cObject = FILE
+        source.cObject = FLUIDTEMPLATE
         source.cObject.file = fileadmin/xpath/collection.xml
 
         expression = //title


### PR DESCRIPTION
FILE Content Object is deprecated in version10.