### PR TITLE
 Refactoring for compatibility with TYPO3 v10

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,10 +4,9 @@ if (!defined('TYPO3_MODE')) {
 }
 
 // defines content object XPATH
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][] = array(
-    0 => 'XPATH',
-    1 => 'Digicademy\CobjXpath\ContentObject\XpathContentObject',
-);
+$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'], [
+    'XPATH' =>  Digicademy\CobjXpath\ContentObject\XpathContentObject::class
+]);
 
 // define example RTE preset for XPATH TypoTag in TYPO3 8.7
 $GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['cobj_xpath'] = 'EXT:cobj_xpath/Configuration/RTE/Default.yaml';


### PR DESCRIPTION
"TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass']" is deprecated. (Deprecation: #90937)