### PR TITLE
method-exist check for getContentObjectRenderer added

### DIFF
--- a/Classes/ContentObject/XpathContentObject.php
+++ b/Classes/ContentObject/XpathContentObject.php
@@ -52,7 +52,12 @@ class XpathContentObject extends AbstractContentObject
             return '';
         }
 
-        $ContentObjectRenderer = $this->getContentObjectRenderer();
+        // check which getter method for renderer is supported in the current T3 version
+        if (method_exists($this->configurationManager , "getContentObjectRenderer")) {
+            $ContentObjectRenderer = $this->getContentObjectRenderer() ;
+        } else {
+            $ContentObjectRenderer = $this->getContentObject() ;
+        }
 
         $content = '';
 


### PR DESCRIPTION
method getContentObjectRenderer() doesn't exist in T3 7.6, check if method exists added @metacontext 